### PR TITLE
Updating Podspec to use dependency on AsyncDisplayKit/Core

### DIFF
--- a/WebASDKImageManager.podspec
+++ b/WebASDKImageManager.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source_files = [
     'WebASDKImageManager/*.{h,m}'
   ]
-  s.dependency 'AsyncDisplayKit', '~> 1.9'
+  s.dependency 'AsyncDisplayKit/Core', '~> 1.9'
   s.dependency 'SDWebImage/Core', '~> 3.7'
 end


### PR DESCRIPTION
Update podspec to use dependency of AsyncDisplayKit/Core instead of AsyncDisplayKit
